### PR TITLE
Fix connection issue

### DIFF
--- a/src/chessrl/selfplay.py
+++ b/src/chessrl/selfplay.py
@@ -15,6 +15,7 @@ import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '1'
 
 
+
 def process_initializer():
     """ Initializer of the training threads in in order to detect if there
     is a GPU available and use it. This is needed to initialize TF inside the
@@ -28,7 +29,6 @@ def process_initializer():
 
 
 multiprocessing.set_start_method('spawn', force=True)
-
 
 def get_model_path(directory):
     """ Finds all the .h5 files (neural net weights) and returns the path to
@@ -60,6 +60,7 @@ def play_game(agent):
     logger = Logger.get_instance()
 
     player_color = True if random.random() >= 0.5 else False
+    logger.debug(f"Player is white: {player_color}")
 
     gam = Game(player_color=player_color)
     agent.color = player_color
@@ -72,13 +73,14 @@ def play_game(agent):
     while gam.get_result() is None:
         start = timer()
         bm, am = agent.best_move(gam, real_game=False, ai_move=True,
-                                 max_iters=900)
+                                 max_iters=100)
         gam.move(bm)  # Make our move
         gam.move(am)  # Make oponent move
         end = timer()
         elapsed = round(end - start, 2)
         logger.debug(f"\tMade move: {bm}, took: {elapsed} secs")
     logger.debug(gam.get_history())
+
     return gam
 
 
@@ -147,6 +149,7 @@ def main():
         proci.start()
         proci.join()
 
+        logger.debug("Stopping worker")
         worker.stop()
 
         logger.info(f"\tTraining {i+1} of {args.games}")

--- a/src/chessrl/selfplay.py
+++ b/src/chessrl/selfplay.py
@@ -15,7 +15,6 @@ import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '1'
 
 
-
 def process_initializer():
     """ Initializer of the training threads in in order to detect if there
     is a GPU available and use it. This is needed to initialize TF inside the
@@ -29,6 +28,7 @@ def process_initializer():
 
 
 multiprocessing.set_start_method('spawn', force=True)
+
 
 def get_model_path(directory):
     """ Finds all the .h5 files (neural net weights) and returns the path to

--- a/src/chessrl/selfplay.py
+++ b/src/chessrl/selfplay.py
@@ -73,7 +73,7 @@ def play_game(agent):
     while gam.get_result() is None:
         start = timer()
         bm, am = agent.best_move(gam, real_game=False, ai_move=True,
-                                 max_iters=100)
+                                 max_iters=900)
         gam.move(bm)  # Make our move
         gam.move(am)  # Make oponent move
         end = timer()
@@ -87,6 +87,7 @@ def play_game(agent):
 def play_game_job(endpoint, result_placeholder, threads):
     agent = AgentDistributed(Game.WHITE, endpoint=endpoint,
                              num_threads=threads)
+    agent.connect()
     gam = play_game(agent)
 
     d = DatasetGame()


### PR DESCRIPTION
With lots of threads, sometimes the Cient connections were garbage collected and this caused the worker to crash, stalling the self-play process.

Now, the agents not longer share a pool of connections, but they initialize theirs on each MCTS iteration. 

Also, the worker adds the checking of client side closed connections and removing them from the active connections.